### PR TITLE
WIP: Fix the module name case issue

### DIFF
--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
@@ -41,7 +41,6 @@ class SdistDownloader extends DependencyDownloader {
 
     @Override
     def downloadDependency(String dep) {
-        log.info("Pulling in $dep")
         def (String name, String version) = dep.split(":")
 
         def projectDetails = cache.getDetails(name)
@@ -57,6 +56,8 @@ class SdistDownloader extends DependencyDownloader {
         }
 
         name = IvyFileWriter.getActualModuleName(sdistDetails.filename, version)
+        dep = name + dep.substring(name.length())
+        log.info("Pulling in $dep")
 
         def destDir = Paths.get(ivyRepoRoot.absolutePath, SOURCE_DIST_ORG, name, version).toFile()
         destDir.mkdirs()

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
@@ -55,9 +55,9 @@ class SdistDownloader extends DependencyDownloader {
             throw new RuntimeException("Unable to find source dist for $dep")
         }
 
-        name = IvyFileWriter.getActualModuleName(sdistDetails.filename, version)
-        dep = name + dep.substring(name.length())
-        log.info("Pulling in $dep")
+        // make sure the module name has the right letter case as PyPI
+        name = IvyFileWriter.getActualModuleNameFromFilename(sdistDetails.filename, version)
+        log.info("Pulling in $name:$version")
 
         def destDir = Paths.get(ivyRepoRoot.absolutePath, SOURCE_DIST_ORG, name, version).toFile()
         destDir.mkdirs()

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
@@ -56,6 +56,8 @@ class SdistDownloader extends DependencyDownloader {
             throw new RuntimeException("Unable to find source dist for $dep")
         }
 
+        name = IvyFileWriter.getActualModuleName(sdistDetails.filename, version)
+
         def destDir = Paths.get(ivyRepoRoot.absolutePath, SOURCE_DIST_ORG, name, version).toFile()
         destDir.mkdirs()
 

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/WheelsDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/WheelsDownloader.groovy
@@ -31,12 +31,11 @@ class WheelsDownloader extends DependencyDownloader {
 
     @Override
     def downloadDependency(String dep) {
-        log.info("Pulling in $dep")
         def (String name, String version, String classifier) = dep.split(":")
 
         def projectDetails = cache.getDetails(name)
         version = projectDetails.maybeFixVersion(version)
-        def wheelDetails = projectDetails.findVersion(version).find { it.filename == "${name}-${version}-${classifier}.whl" }
+        def wheelDetails = projectDetails.findVersion(version).find { it.filename.equalsIgnoreCase("${name}-${version}-${classifier}.whl") }
 
         if (wheelDetails == null) {
             if (lenient) {
@@ -45,6 +44,10 @@ class WheelsDownloader extends DependencyDownloader {
             }
             throw new RuntimeException("Unable to find wheels for $dep")
         }
+
+        // make sure the module name has the same letter case as PyPI
+        name = IvyFileWriter.getActualModuleNameFromFilename(wheelDetails.filename, version)
+        log.info("Pulling in $name:$version:$classifier")
 
         def destDir = Paths.get(ivyRepoRoot.absolutePath, BINARY_DIST_ORG, name, version, classifier).toFile()
         destDir.mkdirs()

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/ivy/IvyFileWriter.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/ivy/IvyFileWriter.groovy
@@ -24,7 +24,7 @@ import org.apache.commons.io.FilenameUtils
 
 @TupleConstructor
 class IvyFileWriter {
-    final String name
+    String name
     final String version
     final String packageType
     final List<VersionEntry> archives
@@ -82,6 +82,7 @@ class IvyFileWriter {
         def publicationMap = archives.collect { artifact ->
             def ext = artifact.filename.contains(".tar.") ? artifact.filename.find('tar\\..*') : FilenameUtils.getExtension(artifact.filename)
             String filename = artifact.filename - ("." + ext)
+            this.name = getActualModuleName(filename, version)
             def source = SdistDownloader.SOURCE_DIST_PACKAGE_TYPE == artifact.packageType
             def map = [name: name, ext: ext, conf: source ? 'source' : 'default', type: ext]
 
@@ -96,6 +97,10 @@ class IvyFileWriter {
 
     private String getClassifier(String filename) {
         return filename.substring(filename.indexOf(version) + version.length() + 1)
+    }
+
+    static String getActualModuleName(String filename, String revision) {
+        return filename.substring(0, filename.indexOf(revision) - 1)
     }
 
     private String getOrganisation() {

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/ivy/IvyFileWriter.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/ivy/IvyFileWriter.groovy
@@ -82,12 +82,12 @@ class IvyFileWriter {
         def publicationMap = archives.collect { artifact ->
             def ext = artifact.filename.contains(".tar.") ? artifact.filename.find('tar\\..*') : FilenameUtils.getExtension(artifact.filename)
             String filename = artifact.filename - ("." + ext)
-            this.name = getActualModuleName(filename, version)
+            this.name = getActualModuleNameFromFilename(filename, version)
             def source = SdistDownloader.SOURCE_DIST_PACKAGE_TYPE == artifact.packageType
             def map = [name: name, ext: ext, conf: source ? 'source' : 'default', type: ext]
 
             if (filename.indexOf(version) + version.length() + 1 < filename.length()) {
-                map['m:classifier'] = getClassifier(filename)
+                map['m:classifier'] = getClassifierFromFilename(filename)
             }
             return map
         }
@@ -95,11 +95,17 @@ class IvyFileWriter {
         return publicationMap
     }
 
-    private String getClassifier(String filename) {
+    private String getClassifierFromFilename(String filename) {
         return filename.substring(filename.indexOf(version) + version.length() + 1)
     }
 
-    static String getActualModuleName(String filename, String revision) {
+    /**
+     * Get the actual module name from artifact name, which has the correct letter case.
+     * @param filename the filename of artifact
+     * @param revision module version
+     * @return actual module name, which is from PyPI
+     */
+    static String getActualModuleNameFromFilename(String filename, String revision) {
         return filename.substring(0, filename.indexOf(revision) - 1)
     }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.8.0
+version=0.8.1


### PR DESCRIPTION
The letter case of users' input arguments might be different from PyPI, such as WMI and MarkupSafe, PyPI is case-insensitive, but ivy and Artifactory are case-sensitive, we should make pivy-importer smart enough to help user correct the module name even they are using wrong cases for convenience, we can see the module name fix in log, path, ivy file name and ivy file contents.

With my change, the logs become
 qlan@QLAN2 C:\Users\qlan\Downloads\test
$ java -jar pivy-importer-0.8.0-SNAPSHOT-all.jar --repo ivy-repo markupsafe:1.0
08:54:23.242 INFO  c.l.p.importer.deps.SdistDownloader - Pulling in MarkupSafe:1.0
08:54:23.348 INFO  c.l.python.importer.ImporterCLI - Execution Finished!

The path and filename become C:\Users\qlan\Downloads\test\ivy-repo\pypi\MarkupSafe\1.0\MarkupSafe-1.0.ivy

ivy file contents use MarkupSafe for both module name and artifact name.